### PR TITLE
Add configuration for path prefix and interval

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,5 +15,7 @@ statsdhandler:
   enable: True
   host: tbd
   port: 8125
+interval: 30
+path_prefix: "servers"
 # Override this from your playbook
 diamond_collector_extra_defs:

--- a/templates/diamond.conf
+++ b/templates/diamond.conf
@@ -71,7 +71,7 @@ batch = 1
 ### Options for GraphitePickleHandler
 
 # Graphite server host
-host = {{ graphitehandler.port }}
+host = {{ graphitehandler.host }}
 
 # Port to send metrics to
 port = 2004
@@ -163,7 +163,7 @@ batch = 100
 # you can use one or both to craft the path where you want to put metrics
 # such as: %(path_prefix)s.$(hostname)s.$(path_suffix)s.$(metric)s
 # path_prefix = servers
-# path_suffix =
+path_suffix = {{ path_prefix }}
 
 # Path Prefix for Virtual Machines
 # If the host supports virtual machines, collectors may report per
@@ -173,7 +173,7 @@ batch = 100
 # instance_prefix = instances
 
 # Default Poll Interval (seconds)
-# interval = 300
+interval = {{ interval }}
 
 ################################################################################
 ### Options for logging


### PR DESCRIPTION
Fix problem with GraphitePickleHandler configuration
Add new variables to template:
	 * `path_prefix` ("servers")
	 * `interval` (30)